### PR TITLE
Record the half-precision cost of the benchmark network widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,8 +103,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The widths are now 10 (harmonic oscillator), 8 (pendulum) and 10 (double pendulum). The
   pendulum's is an optimum rather than a maximum — its degenerate `ϑ` leaves the parameter
   Jacobian singular, so a wider network enlarges the null space and `S = 12` diverges outright.
-  The cost is at half precision, where wider networks are harder to condition and convergence
-  falls. The Toda lattice has no measured width yet, which puts its quick grid at ~5 h against
+  The cost is at half precision, and is a deliberate trade rather than an oversight: on the
+  harmonic oscillator's full quick grid, `Float16` convergence falls from 17/36 at `S = 4` to
+  12/36 at `S = 8` and 9/36 at `S = 10`, while the best `Float64` `ref_err` improves from
+  2.8e-06 to 3.4e-14. A wider network puts more nearly dependent columns in the parameter
+  Jacobian, and 11 bits of mantissa cannot separate them. Accuracy is what the suite reports and
+  half precision is studied on its own terms in the OGA section, so the widths favour `Float64`;
+  `S` is the knob if that priority ever inverts. See "The half-precision trade-off" on the
+  Benchmarks page. The Toda lattice has no measured width yet, which puts its quick grid at ~5 h against
   ~7 min for the other three, so it is out of the docs build until it has one;
   `benchmark/run_toda_lattice.jl` and the `full` preset still run it.
 - `quick` no longer overrides `max_iterations`, using the solver default of 1000; the `maxiter`

--- a/docs/src/Benchmarks/benchmarks.md
+++ b/docs/src/Benchmarks/benchmarks.md
@@ -111,10 +111,32 @@ Three different shapes, which is why one global value will not do:
 - The **double pendulum** falls monotonically and then flattens: the gain from `S = 10` to
   `S = 12` is nothing, so `S = 10` is where it stops.
 
-There is a cost at half precision. As `S` grows the harmonic oscillator's `Float16`
-convergence *falls* — 17, then 12, then 9 of 36 cases at `S = 4`, `8`, `10` — because a wider
-network is harder to condition in 11 bits of mantissa. The widths above are chosen for
-`Float64` accuracy, and that choice is paid for in the `Float16` column.
+#### The half-precision trade-off
+
+The widths above are chosen for `Float64` accuracy, and that choice is paid for at `Float16`.
+It is a deliberate trade, not an oversight, so the size of it is recorded here.
+
+As `S` grows, `Float16` convergence *falls* while `Float64` accuracy improves. Measured on the
+harmonic oscillator over the whole `quick` grid (36 cases per width, both solvers, three
+timesteps, two activations):
+
+| `S` | `Float16` converged | best `Float64` `ref_err` |
+|---|---|---|
+| 4 | 17 / 36 | 2.8e-06 |
+| 8 | 12 / 36 | 1.9e-11 |
+| 10 | **9 / 36** | **3.4e-14** |
+
+A wider network is harder to condition in 11 bits of mantissa: more neurons means more nearly
+dependent columns in the parameter Jacobian, and half precision has no digits to spare in
+distinguishing them. So the same change that buys eight orders of magnitude at double precision
+costs roughly half the half-precision cases.
+
+The widths were chosen this way because accuracy is what the suite exists to report and because
+`Float16` is a robustness study rather than a production precision here — the
+[Orthogonal Greedy Algorithm Initial Guess](@ref) section covers half precision on its own
+terms, with the seed measured directly rather than through a solve. If half-precision robustness were the
+priority instead, `S` is the knob: `S = 4` nearly doubles the `Float16` success rate, at the
+cost of everything in the table above.
 
 ## Metrics
 
@@ -217,6 +239,10 @@ column is the flip side: reaching 1.8e-15 takes the whole budget when it is reac
 `Float16` converges in a couple of iterations because its tolerance is 0.0078, and its
 accuracy is correspondingly the worst by four orders of magnitude. Success rate and accuracy
 are answering different questions.
+
+The 25% in that `Float16` row is also *lower* than it would be with a narrower network — see
+[The half-precision trade-off](@ref) for the measurement and why the widths were chosen that
+way regardless.
 
 Success rate broken down by problem, by solver strategy, and by solver × precision:
 


### PR DESCRIPTION
Follow-up to #60, which merged before this last piece was pushed. Documentation and changelog only — no code changes.

## What this records

The per-problem network widths measured in #60 (`S` = 10 / 8 / 10) were chosen for `Float64` accuracy, and `Float16` convergence pays for that. #60 noted it in a single clause. A reader who cares about half precision needs to be able to find it, and "we made this worse on purpose" is exactly the kind of claim that should carry its measurement — so it is now a labelled subsection with the numbers.

Measured on the harmonic oscillator over the whole `quick` grid (36 cases per width: both solvers × three timesteps × two activations):

| `S` | `Float16` converged | best `Float64` `ref_err` |
|---|---|---|
| 4 | 17 / 36 | 2.8e-06 |
| 8 | 12 / 36 | 1.9e-11 |
| 10 | **9 / 36** | **3.4e-14** |

The change that buys eight orders of magnitude at double precision costs roughly half the half-precision cases. Mechanism: a wider network puts more nearly dependent columns in the parameter Jacobian, and 11 bits of mantissa cannot separate them.

## Why the widths stay as they are

Stated in the page so the decision is auditable rather than merely disclosed:

- Accuracy is what the benchmark suite exists to report.
- Half precision is studied on its own terms in the *Orthogonal Greedy Algorithm* section, where the seed is measured **directly** rather than through a solve — so this `Float16` column is not the load-bearing evidence for half-precision robustness.
- `S` is named as the knob if that priority ever inverts, together with what turning it costs: `S = 4` nearly doubles the `Float16` success rate and gives up everything in the table above.

## Changes

- `docs/src/Benchmarks/benchmarks.md` — new *The half-precision trade-off* subsection with the table and mechanism, cross-referenced from the summary where a reader first meets the 25% `Float16` figure.
- `CHANGELOG.md` — the clause replaced by the measured numbers.

## Verification

- Documentation builds clean (no cross-reference, citation or anchor warnings).
- Full test suite passes via the pre-push hook; no source files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
