### PR TITLE
Compare the OGA components on one page and document the adapter layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The OGA section gains an at-a-glance comparison and documents the adapter layer.** Three
+  tables at the top of *Algorithms* compare the dictionaries, the selection rules and the fits
+  on what they add, what they cost and how they behave on a dependent atom — the design-level
+  view, next to the measured ranking in *Studies* and the prescriptive list in *Usage*. Two
+  implementation decisions that previously reached the manual only through docstrings are now
+  on the page: the `rtol` default of `PivotedQR`/`TruncatedSVD` (`eps(T)·max(4, k)`, and why
+  not `sqrt(eps(T))` — that is the scale of the rank-gain floor, so truncating there would
+  discard the directions selection just admitted), and the power-of-two dictionary rescaling
+  that opens the greedy loop.
+
+  *Usage* gains the glue between `oga_fit` and the integrators, which `src/oga/adapters.jl`
+  had but no page stated: the seed runs **one independent greedy fit per degree of freedom**,
+  its target is the `initial_trajectory_method` estimate rather than the solution, and the node
+  count and Simpson weights both come from `extrapolation_substep` — which is where the `M = 11`
+  assumed throughout *Algorithms* comes from. Also that `TrainingMethod` is an alternative seed
+  for `ShallowNet`, and that `show_status` (on by default) is what prints the per-component
+  neuron count, residual and rejection count.
+
 ### Fixed
+
+- The OGA *Precision* page said `[compat]` pins GeometricIntegratorsBase 0.5; it has required
+  0.6.3 since the SimpleSolvers 0.12 upgrade. The argument for the bound — an `f_abstol` that
+  scales with `datatype(problem)`, and defaults that merge with the caller's options rather than
+  being substituted away — is unchanged.
 
 - **The documentation deploys again on a tag.** `deploydocs` was called with `devurl = "stable"`,
   publishing `main` at `/stable/`. Its default `versions` is `["stable" => "v^", "v#.#", devurl =>

--- a/docs/src/oga/algorithms.md
+++ b/docs/src/oga/algorithms.md
@@ -9,6 +9,52 @@ Throughout, `M` is the number of quadrature nodes (11 by default), `N` the dicti
 formulas are in the ``\sqrt{w}``-scaled space, where the Euclidean inner product *is* the
 quadrature-weighted one.
 
+## At a glance
+
+The three tables below summarise the components against each other; each row is expanded in
+its own subsection later on the page. This is the *design-level* comparison — what each
+component computes and costs. For how the variants actually performed when measured, see
+[Studies](@ref); for a prescriptive "which one should I pick", see *Choosing a variant* on the
+[Usage](@ref) page.
+
+**Dictionaries** — which candidate neurons are on offer.
+
+| Dictionary | Atom set | Size `N` | Needs | Reach for it when |
+|---|---|---|---|---|
+| [`BiasGrid1d`](@ref) | `{±1} ×` bias grid | ``2(\texttt{dict\_amount}+1)`` | — | `ReLUᵏ`, where it is provably complete |
+| [`WeightBiasGrid2d`](@ref) | log-spaced ``\lvert w\rvert`` × bias grid | ``n_w (n_b + 1)`` | [`NormalizedProjection`](@ref) | ELU, GELU, tanh — `w` is a real length scale |
+| [`AngularGrid`](@ref) | rays ``r(\cos\theta, \sin\theta)`` | ``\lvert\texttt{radii}\rvert (\texttt{amount}+1)`` | [`NormalizedProjection`](@ref) | uniform coverage in atom space; smooth activations, and `ReLUᵏ` too |
+| [`Refined`](@ref) | any of the above, polished off-grid | unchanged, ``+4\,\texttt{iterations}`` scores | — | the grid is coarse, or `N` is a cost problem |
+
+`WeightBiasGrid2d` restricted to ``\lvert w\rvert = 1`` reproduces `BiasGrid1d` exactly, so the
+2-D dictionaries are strict generalisations rather than alternatives.
+
+**Selection rules** — how the greedy step ranks candidates against the residual.
+
+| Rule | Score | Extra cost per step | Scale-invariant | Reach for it when |
+|---|---|---|---|---|
+| [`RawProjection`](@ref) | ``\lvert\langle r, g\rangle_w\rvert`` | — | no | the `±1` grid at `Float64`; the pinned default |
+| [`NormalizedProjection`](@ref) | ``\lvert\langle r, g\rangle_w\rvert / \lVert g\rVert_w`` | precomputed norms | yes | any 2-D dictionary — mandatory there |
+| [`OrthogonalProjection`](@ref) | ``\lvert\langle r, g\rangle_w\rvert / \lVert g^{\perp}\rVert_w`` | one ``O(NMk)`` product | yes | reduced precision: it makes a rank-deficient selected set impossible |
+
+All three cost the ``O(NM)`` scan that dominates the whole algorithm; the column above is what
+each adds on top of it. Only `OrthogonalProjection` can *refuse* an atom.
+
+**Fits** — how the output weights are refit after every selection.
+
+| Fit | Factorisation | Cost per step | On a dependent atom | Reach for it when |
+|---|---|---|---|---|
+| [`WeightedQR`](@ref) | fresh QR of ``\hat A`` | ``O(Mk^2)`` | solves through it (ridged fallback if non-finite) | the default; conditioning ``\kappa(\hat A)`` is enough |
+| [`IncrementalQR`](@ref) | QR maintained across steps | ``O(Mk)`` | same, but the rank gain is reported | paired with `OrthogonalProjection`, whose `Q` it supplies |
+| [`PivotedQR`](@ref) | pivoted Householder QR | ``O(Mk^2)`` | detects it, gives it a zero coefficient | rank deficiency should be visible, not absorbed |
+| [`TruncatedSVD`](@ref) | one-sided Jacobi SVD | ``O(Mk^2)`` per sweep | drops the direction, returns the minimum-norm solution | one configuration must hold at every precision |
+| [`NormalEquationsFit`](@ref) | Gram solve, ``\kappa^2`` | ``O(Mk^2 + k^3)`` | throws; caught and ridged | measuring the baseline, not solving a problem |
+
+Every one of them is wrapped by [`oga_solve`](@ref NonlinearIntegrators.oga_solve), which
+guarantees a finite result of the right length whatever the factorisation does — and, as the
+note under *Fits* argues, all five are free at this problem size, so the choice is purely a
+numerical one.
+
 ## The greedy loop
 
 [`oga_fit`](@ref) is the single implementation shared by all four network integrators. It
@@ -22,6 +68,12 @@ oga_fit(oga, σ, nodes, w, y, nneurons;
         bias_interval, dict_amount, modulation = nothing, symmetry = NoSymmetry())
     -> OGAResult
 ```
+
+Before the loop starts, the whole dictionary is rescaled by a single **power of two** so that
+the largest atom has norm ≈ 1. Being a power of two, that is an exact operation, so `Float64`
+and `Float32` atom selection is unchanged bit for bit; it exists for `Float16`, where squared
+norms overflow long before the norms themselves do. The argument is on the [Precision](@ref)
+page.
 
 Per step it:
 
@@ -303,6 +355,14 @@ detect, and at ``k \le 8`` columns the recomputation is free; the reflector foll
 LAPACK convention
 (``v_1 = 1``, unnormalised) to avoid a division that can underflow at half precision.
 
+The default `rtol` is ``\varepsilon(T)\max(4, k)``, following `pinv`'s convention of
+``\varepsilon(T)`` times the dimension — the level at which a singular direction is
+indistinguishable from accumulated rounding. Deliberately *not* ``\sqrt{\varepsilon(T)}``: that
+is the scale of [`OrthogonalProjection`](@ref)'s rank-gain floor, which admits a column whose
+orthogonal part is exactly that fraction of its norm, so truncating there would discard the very
+directions the selection rule has just decided are usable. Measured at `Float16`, the two
+thresholds differ by a factor of 20 in the resulting fit residual.
+
 *Cost.* ``O(Mk^2)`` per step, plus the pivot search.
 
 ### [`TruncatedSVD`](@ref)
@@ -331,6 +391,10 @@ independent.
     threshold becomes `Inf`, every column pair tests as "already orthogonal", and the routine
     silently returns the **unrotated** matrix: wrong singular values, no error raised. This
     was a real bug, caught by comparing against LAPACK at `Float16`.
+
+The default `rtol` is ``\varepsilon(T)\max(4, k)``, for the same reason as
+[`PivotedQR`](@ref) above: a ``\sqrt{\varepsilon(T)}`` cut would collide with the rank-gain
+floor and drop directions the selection rule just admitted.
 
 *Cost.* ``O(Mk^2)`` per sweep, a handful of sweeps at ``k \le 8``.
 

--- a/docs/src/oga/oga.md
+++ b/docs/src/oga/oga.md
@@ -17,7 +17,7 @@ All of it lives in `src/oga/`, behind a single composable type.
 | Page | Contents |
 |---|---|
 | [Theory](@ref) | what is being approximated, why the classical dictionary has `±1` weights, the greedy selection criterion and where it comes from, the conditioning analysis |
-| [Algorithms](@ref) | every dictionary, selection rule and fit in turn — mechanism, implementation, cost, when to use |
+| [Algorithms](@ref) | the components compared at a glance, then every dictionary, selection rule and fit in turn — mechanism, implementation, cost, when to use |
 | [Usage](@ref) | presets, composing your own, per-integrator behaviour, reading the result, extending |
 | [Precision](@ref) | the no-implicit-conversion invariant, how it is enforced, and the `Float16` traps |
 | [Studies](@ref) | the two-tier measurement setup and what it found |
@@ -43,8 +43,8 @@ type rather than enumerated as a type per combination:
 - **selection** ([`OGASelection`](@ref)) — how candidates are ranked against the residual;
 - **fit** ([`OGAFit`](@ref)) — how the output weights are refit.
 
-Named presets recover the useful corners: [`OGA1d`](@ref) (the default, and the
-default), [`OGA1dNormalized`](@ref), [`OGA1dStable`](@ref),
+Named presets recover the useful corners: [`OGA1d`](@ref) (the default),
+[`OGA1dNormalized`](@ref), [`OGA1dStable`](@ref),
 [`OGA2d`](@ref), [`OGASphere`](@ref). The original-paper reference implementation is kept
 separately as [`OGA1dNormalEquations`](@ref).
 

--- a/docs/src/oga/precision.md
+++ b/docs/src/oga/precision.md
@@ -114,7 +114,7 @@ than degrading it.
 The integrator default is
 ``f_{\text{abstol}} = \max(8, \texttt{solversize})\,\varepsilon(\texttt{datatype(problem)})``
 — scaled to the working precision, and merged with any options the caller passes. Both
-properties are required of the dependency (`[compat]` pins GeometricIntegratorsBase 0.5),
+properties are required of the dependency (`[compat]` pins GeometricIntegratorsBase 0.6.3),
 because an absolute tolerance that does not scale with `eps(T)` is simply unreachable in
 reduced precision: at `Float32` (``\varepsilon \approx 1.2\times10^{-7}``) or `Float16`
 (``\approx 9.8\times10^{-4}``) the run then sits at its residual floor and burns the entire

--- a/docs/src/oga/usage.md
+++ b/docs/src/oga/usage.md
@@ -106,7 +106,39 @@ integrator's estimate), `ShallowNetAutodiffReversible` uses the cache's endpoint
 and both write that endpoint into the nonlinear solution vector, which the symbolic-derivative
 variants do not (there the corresponding slot is the momentum, set by `initial_trajectory!`).
 
-`DenseNet` has no OGA seed; it uses `TrainingMethod` or `LSGD`.
+The OGA is the default seed but not the only one: `initial_guess_method = TrainingMethod()` trains
+the network by gradient descent instead, for `training_epochs` epochs. `DenseNet` has no OGA seed
+at all; it uses `TrainingMethod` or `LSGD`.
+
+### How the seed reaches the integrator
+
+`initial_params!` is the extension point the framework calls once per time step, and the glue
+between it and the integrator-agnostic `oga_fit` is `src/oga/adapters.jl`. Three properties of
+that layer are worth knowing, because they are not visible from `oga_fit`'s signature.
+
+**One greedy fit per degree of freedom.** `oga_seed` loops over the `D` components of the problem
+and calls [`oga_fit`](@ref) separately for each, so a double pendulum performs two independent
+greedy fits per time step, each selecting its own atoms. Only the dictionary configuration and the
+quadrature are shared. Nothing couples the components at the seeding stage — the coupling enters
+with the Newton solve.
+
+**The fit target is the initial trajectory.** It is the integrator's `network_labels`, i.e. the
+trajectory estimate produced by `initial_trajectory_method` (`IntegratorExtrapolation` by default,
+which integrates a sub-problem with `ImplicitMidpoint`), sampled at the network's input nodes. So
+the OGA does not fit the *solution*; it fits a cheap approximation of it, and its job is to place
+neurons where that approximation has structure. For the two boundary-ansatz integrators the
+straight line between the endpoints is subtracted first, and the `t(1-t)` factor is passed as
+`oga_fit`'s `modulation` — that is all `_ansatz_modulation` does.
+
+**The node count and the quadrature come from `extrapolation_substep`.** The nodes are
+`0 : 1/extrapolation_substep : 1` and the weights are
+`simpson_quadrature(extrapolation_substep, T)` — always at `T`, see [Precision](@ref). The default
+of 10 sub-steps is where the `M = 11` quadrature nodes assumed throughout [Algorithms](@ref) come
+from, and Simpson's rule is why the value must be even.
+
+Per-step diagnostics are printed by default: `show_status = true` on the method makes each seed
+report, per component, how many neurons it placed, the weighted residual it reached, and how many
+atoms were rejected for adding no new direction. Set `show_status = false` to silence it.
 
 ## Reading the result
 


### PR DESCRIPTION
The OGA section was flagged as not reflecting the recent work in that area. The audit does not
bear that out: all four dictionaries, three selection rules, five fits, the guard rails, the
presets and the `OGA1dNormalEquations` baseline are already described across the six pages, and
every cross-reference resolves. What was missing is narrower, and this PR fills it.

## Algorithms — an at-a-glance comparison

Three tables at the top of the page, so the components can be weighed against each other without
reading five subsections:

- **dictionaries** by atom set, size `N` and the selection rule they require;
- **selection rules** by score, cost added on top of the shared `O(NM)` scan, and scale invariance;
- **fits** by factorisation, per-step cost and what each does with a numerically dependent atom.

Each row links to the prose below it. This is the design-level view; it points at *Studies* for the
measured ranking and at *Usage* for the prescriptive decision guide, so the three do not compete.

Two decisions that reached the manual only through docstrings join them:

- the `rtol` default of `PivotedQR`/`TruncatedSVD` — `eps(T)*max(4, k)`, and why deliberately not
  `sqrt(eps(T))`: that is the scale of `OrthogonalProjection`'s rank-gain floor, so truncating
  there would discard the very directions selection has just admitted (a factor of 20 in the
  `Float16` fit residual, measured);
- the power-of-two dictionary rescaling that opens the greedy loop, cross-referenced to *Precision*
  rather than restated.

## Usage — how the seed reaches the integrator

`src/oga/adapters.jl` has had this all along, but no page stated it:

- the seed runs **one independent greedy fit per degree of freedom**, sharing only the dictionary
  configuration and the quadrature;
- the fit target is the `initial_trajectory_method` estimate, not the solution — the OGA places
  neurons where a cheap approximation has structure;
- the nodes and the Simpson weights both come from `extrapolation_substep`, which is where the
  `M = 11` assumed throughout *Algorithms* comes from, and why the value must be even.

Also that `TrainingMethod` is an alternative seed for `ShallowNet`, and that `show_status` — on by
default — is what prints the per-component neuron count, residual and rejection count.

## Fixed

*Precision* claimed `[compat]` pins GeometricIntegratorsBase 0.5; it has required 0.6.3 since the
SimpleSolvers 0.12 upgrade. The argument for the bound — an `f_abstol` that scales with
`datatype(problem)`, and defaults that merge with the caller's options rather than being
substituted away — is unchanged.

## Verification

Documentation only; no source file is touched, and the *Studies* numbers are untouched (no sweep
re-run). Built locally with `SKIP_SHALLOWNET_BENCH=true julia --project=docs docs/make.jl` —
`makedocs` runs strict, so the clean build is the check that every new cross-reference resolves;
the 16 links in the new section were confirmed against the rendered HTML. The pre-push hook ran the
full suite: 1957/1957 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)