### PR TITLE
Take Julia 1.11 and GeometricOptimizers 0.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
             fail-fast: false
             matrix:
                 version:
-                    - "1.10"
+                    - "1.11"
                     - "1.12"
                     - "^1.13.0-0"
                 os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearIntegrators"
 uuid = "4ad56de4-0342-4c02-9694-ab2f23251d8c"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]
@@ -36,8 +36,11 @@ GeometricEquations = "0.21"
 GeometricIntegratorsBase = "0.6.3"
 # 0.5.0 drops the `ParameterHandling` shim and lets `NeuralNetworkParameters` do the flattening,
 # which makes the 0.2 container a requirement rather than a choice: 0.4 and earlier want the 0.1
-# container. This bound and the two below therefore move together or none of them resolves.
-GeometricOptimizers = "0.5"
+# container. This bound and the two below therefore move together or none of them resolves. 0.6.0
+# takes a whole `NetworkParameters` through the optimizer; nothing here hands it one -- the
+# `ShallowNet` initialisation flattens to a plain `Vector` before `Optimizer` sees it
+# (`src/nvi/shallownet.jl`) -- so the bump is a compat entry and no code.
+GeometricOptimizers = "0.6"
 GeometricSolutions = "0.6"
 LinearAlgebra = "1"
 # 0.2.1 and not 0.2. The call sites here name only `NetworkParameters`, `params`, `flatten`,
@@ -48,8 +51,10 @@ LinearAlgebra = "1"
 # (NeuralNetworkParameters#13). Against 0.2.0 the `ShallowNet` and `ShallowNetReversible` budgets
 # fail on Julia 1.10 -- that is the downstream half of SymbolicNeuralNetworks#55, whose upstream
 # half is `SymbolicNeuralNetworks` 0.7.0. SNN 0.7 pins 0.2.1 itself, so today's resolution would
-# be right either way; this states the requirement rather than inheriting it.
-NeuralNetworkParameters = "0.2.1"
+# be right either way; this states the requirement rather than inheriting it. 0.2.2 moves the same
+# figure again and downwards, by writing the across-children walks out instead of recursing with
+# `Base.tail`; the budgets below are measured against it.
+NeuralNetworkParameters = "0.2.2"
 QuadratureRules = "0.2"
 Random = "1"
 SimpleSolvers = "0.12.1, 0.13"
@@ -57,7 +62,8 @@ StaticArrays = "1"
 Statistics = "1"
 # 0.7.0 is the first release that permits the 0.2 container; 0.6.0 allows only 0.1. It also
 # carries the upstream half of SymbolicNeuralNetworks#55 -- see the `NeuralNetworkParameters`
-# bound above.
+# bound above. 0.7.1 writes the batched half of that walk out as well, which this package does not
+# reach (`residual!` calls `DQDθ` on a length-one `Vector`) but which moves nothing here either way.
 SymbolicNeuralNetworks = "0.7"
 Symbolics = "7"
-julia = "1.10"
+julia = "1.11"

--- a/test/quality/inference_and_allocations.jl
+++ b/test/quality/inference_and_allocations.jl
@@ -34,37 +34,33 @@ function residual_probe(make, ::Type{T}) where {T}
     return (; int, s, params, x, b)
 end
 
-# Measured on Float64, S = 4, R = 8, D = 1 (bytes per `residual!` call), before → after the
-# audit:
+# Measured on Float64, S = 4, R = 8, D = 1 (bytes per `residual!` call), before the audit → after →
+# **re-measured on Julia 1.11.9 against the current stack**, which is what the ceilings below are set
+# from:
 #
-#   ShallowNet                     21 344 → 11 424   (1.9×)
-#   ShallowNetReversible           26 176 → 11 424   (2.3×)
-#   ShallowNetAutodiff            211 968 → 51 584   (4.1×)
-#   ShallowNetAutodiffReversible  216 800 → 51 584   (4.2×)
+#   ShallowNet                     21 344 → 11 424 → 11 424
+#   ShallowNetReversible           26 176 → 11 424 → 11 424
+#   ShallowNetAutodiff            211 968 → 51 584 → 54 656
+#   ShallowNetAutodiffReversible  216 800 → 51 584 → 54 656
 #
-# One ceiling per row, on every Julia version. That was not true between
-# `SymbolicNeuralNetworks` 0.6.0 and 0.7.0: the two symbolic rows cost 28 096 bytes on Julia 1.10
-# there — 1.85× the 15 168 they cost under SNN 0.5, while 1.11 and later stayed at 11 424 either
-# way — and this file carried a 1.10-only ceiling of 42 000 for them. The cause was a `map` over
-# a closure that 1.10 does not always elide, on the walk that splits a generated function's flat
-# result back into the nesting of the parameters. It is fixed in two independent halves, and
-# `Project.toml` requires both: `SymbolicNeuralNetworks` 0.7.0 for the batched walk and
-# `NeuralNetworkParameters` 0.2.1 for the un-batched one. The symbolic `residual!` here calls
-# `DQDθ` on a length-one `Vector`, so it takes the un-batched path, which is the half that
-# `NeuralNetworkParameters` 0.2.1 carries.
+# The two autodiff rows are 3072 bytes dearer than recorded and the two symbolic rows have not moved
+# at all. Both are worth stating rather than quietly re-recording, because the *prediction* was the
+# other way round: `NeuralNetworkParameters` 0.2.2 took `SymbolicNeuralNetworks`' single-sample split
+# from 768 bytes to 560, and the symbolic `residual!` here calls `DQDθ` on a length-one `Vector`, so
+# that is the path it takes — and it moves this figure by nothing. Measured, not assumed.
 #
-# Measured on Julia 1.10.11, macOS aarch64, holding everything but those two versions fixed —
-# the same probe against both stacks:
+# One ceiling per row, on every Julia version. That was not true between `SymbolicNeuralNetworks`
+# 0.6.0 and 0.7.0: the two symbolic rows cost 28 096 bytes on Julia 1.10 there — 1.85× the 15 168 they
+# cost under SNN 0.5, while 1.11 and later stayed at 11 424 either way — and this file carried a
+# 1.10-only ceiling of 42 000 for them. The cause was a `map` over a closure that 1.10 does not always
+# elide, on the walk that splits a generated function's flat result back into the nesting of the
+# parameters. It is fixed in two independent halves and `Project.toml` requires both:
+# `SymbolicNeuralNetworks` 0.7.0 for the batched walk and `NeuralNetworkParameters` 0.2.1 for the
+# un-batched one.
 #
-#                                 SNN 0.6.0 / NNP 0.1.1   SNN 0.7.0 / NNP 0.2.1
-#   ShallowNet                                   28 096                  15 168
-#   ShallowNetReversible                         28 096                  15 168
-#   ShallowNetAutodiff                           51 584                  51 584
-#   ShallowNetAutodiffReversible                 51 584                  51 584
-#
-# Only the two symbolic rows move, as they did going the other way: the autodiff rows reach their
-# derivatives through `ForwardDiff` rather than a generated kernel. See SymbolicNeuralNetworks#55,
-# reported from this repository's #86.
+# **That whole comparison is now history rather than a live concern**, since 1.10 is no longer a
+# supported version here. It is kept because the shape of it recurs: a defect that shows on one Julia
+# version and not another, in a walk two packages away, found from a budget in this file.
 const RESIDUAL_ALLOC_BUDGET = Dict(
     "ShallowNet"                   => 17_000,
     "ShallowNetReversible"         => 17_000,


### PR DESCRIPTION
Raises the Julia floor to 1.11 and takes `GeometricOptimizers` 0.6, which is the last step of the
wave that started at `NeuralNetworkParameters` #14.

### Compat

`GeometricOptimizers = "0.6"`. 0.6.0 takes a whole `NetworkParameters` through the optimizer and is
breaking: it deletes four `outer!`/`_mul!` methods, one `update!(::BFGSState, ...)`, `add!` on a
parameter set, and two `l2norm` methods that moved upstream to `GeometricBase`. Nothing here hands
it a container — the `ShallowNet` initialisation flattens to a plain `Vector` before `Optimizer` sees
it (`src/nvi/shallownet.jl`) — so this is a compat entry and no code.

`NeuralNetworkParameters = "0.2.2"`, which is what `SymbolicNeuralNetworks` 0.7.1 requires anyway.

Julia 1.11 is the floor, in step with `NeuralNetworkParameters`, `SimpleSolvers`,
`GeometricOptimizers`, `AbstractNeuralNetworks`, `SymbolicNeuralNetworks` and
`GeometricMachineLearning`. `GeometricBase` deliberately stays on 1.10: it is a dependency of many
packages outside this stack, and unlike the solver and optimizer infrastructure it gains nothing
from the raise. CI becomes `1.11 / 1.12 / ^1.13.0-0`.

### The `residual!` budgets moved, and not the way the prediction said

`test/quality/inference_and_allocations.jl` is re-measured on 1.11.9 rather than carried over. Two of
the four rows changed:

| | before the audit | after | re-measured |
|---|---|---|---|
| `ShallowNet` | 21 344 | 11 424 | **11 424** |
| `ShallowNetReversible` | 26 176 | 11 424 | **11 424** |
| `ShallowNetAutodiff` | 211 968 | 51 584 | **54 656** |
| `ShallowNetAutodiffReversible` | 216 800 | 51 584 | **54 656** |

Worth stating rather than quietly re-recording, because the prediction was the other way round.
`NeuralNetworkParameters` 0.2.2 took `SymbolicNeuralNetworks`' single-sample split from 768 bytes to
560, and the symbolic `residual!` here calls `DQDθ` on a length-one `Vector` — so that *is* the path
it takes, and it moves this figure by nothing, while the two **autodiff** rows, which reach their
derivatives through `ForwardDiff` rather than a generated kernel, are 3072 bytes dearer. The ceilings
(17 000 and 78 000) still hold with room, so none of them moves.

The file also carried a 1.10-only ceiling of 42 000 for the two symbolic rows, and a paragraph
explaining the 1.10 `map`-over-a-closure elision behind it. The ceiling goes; the paragraph stays as
history, because the shape of it recurs — a defect that shows on one Julia version and not another,
in a walk two packages away, found from a budget in this file.

Version 0.4.2.
