### PR TITLE
Take the de-piracy wave: NeuralNetworkParameters 0.3 and the five bounds behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The de-piracy wave, taken as a set of compat bounds. Nothing in this package's exported surface
 changes, and neither does any of its code.
 
-### Fixed
-
-- **`test/unit/network_integrators_unit.jl` was a lottery, and it had been one all along.** Every
-  case there builds a network with random weights, and the OGA/Newton path on those weights is
-  ill-conditioned by nature — `Float32` `ShallowNet` under `OGA1dStable` sits close enough to a
-  singular Gram matrix that whether it *is* singular depends on which weights were drawn. Nothing
-  seeded them: the only `Random.seed!` in the suite is in `dispatch_variants_unit.jl`, which
-  `runtests.jl` includes *after* this file, so the draw depended on how many times `rand` had been
-  called by whatever ran earlier — which differs by platform and by Julia version.
-
-  It surfaced here because this release moved dependency versions, but it is not caused by them.
-  Run against `main`'s **unchanged** bounds on the same runners on the same day, the same test fails
-  the same way with `SingularException(13)`: 5 of 13 jobs there, 8 of 13 here, with identical
-  resolved versions of everything either branch touches, while 24 consecutive local runs on macOS ARM
-  passed under both. `main` being green on 2026-08-26 was a draw, not a state.
-
-  The file seeds itself now, before the cross product and independently of the include order.
-
 ### Changed
 
 - **`NeuralNetworkParameters` 0.2.2 → 0.3, `AbstractNeuralNetworks` 0.7.1 → 0.8,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The de-piracy wave, taken as a set of compat bounds. Nothing in this package's exported surface
 changes, and neither does any of its code.
 
+### Fixed
+
+- **`test/unit/network_integrators_unit.jl` was a lottery, and it had been one all along.** Every
+  case there builds a network with random weights, and the OGA/Newton path on those weights is
+  ill-conditioned by nature — `Float32` `ShallowNet` under `OGA1dStable` sits close enough to a
+  singular Gram matrix that whether it *is* singular depends on which weights were drawn. Nothing
+  seeded them: the only `Random.seed!` in the suite is in `dispatch_variants_unit.jl`, which
+  `runtests.jl` includes *after* this file, so the draw depended on how many times `rand` had been
+  called by whatever ran earlier — which differs by platform and by Julia version.
+
+  It surfaced here because this release moved dependency versions, but it is not caused by them.
+  Run against `main`'s **unchanged** bounds on the same runners on the same day, the same test fails
+  the same way with `SingularException(13)`: 5 of 13 jobs there, 8 of 13 here, with identical
+  resolved versions of everything either branch touches, while 24 consecutive local runs on macOS ARM
+  passed under both. `main` being green on 2026-08-26 was a draw, not a state.
+
+  The file seeds itself now, before the cross product and independently of the include order.
+
 ### Changed
 
 - **`NeuralNetworkParameters` 0.2.2 → 0.3, `AbstractNeuralNetworks` 0.7.1 → 0.8,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-30
+
+The de-piracy wave, taken as a set of compat bounds. Nothing in this package's exported surface
+changes, and neither does any of its code.
+
+### Changed
+
+- **`NeuralNetworkParameters` 0.2.2 → 0.3, `AbstractNeuralNetworks` 0.7.1 → 0.8,
+  `SymbolicNeuralNetworks` 0.7 → 0.8, `GeometricOptimizers` 0.6 → 0.7, `SimpleSolvers`
+  "0.12.1, 0.13" → 0.13.2, `GeometricBase` 0.14.8 → 0.14.9.** One constraint again, not six.
+
+  `NeuralNetworkParameters` 0.3.0 removes `ParameterSet`, the `Union{NetworkParameters, NamedTuple}`
+  the rest of this ecosystem dispatched on, because a method written on it was a method on
+  `Base.NamedTuple`. Every other bound follows: 0.8.0, 0.8.0 and 0.7.0 are the first releases of the
+  three packages above that permit the 0.3 container, `GeometricOptimizers` 0.7.0 requires
+  `SimpleSolvers` 0.13.2, and 0.3.0 takes `GeometricBase` as a hard dependency at 0.14.9. Any one of
+  them alone is unsatisfiable.
+
+  **None of it reaches code here.** This package names only `NetworkParameters`, `params`, `flatten`,
+  `unflatten` and `unflatten!` from the container package, and none of those changed; it names neither
+  `ParameterSet` nor `EquationSet` nor `ArrayNamedTuple`. `GeometricOptimizers` 0.7.0 turning a bare
+  `NamedTuple` away at `Optimizer` costs nothing for the reason 0.4.2 already gave: the `ShallowNet`
+  initialisation flattens to a plain `Vector` before `Optimizer` sees it (`src/nvi/shallownet.jl`), so
+  no parameter set is ever handed over whole.
+
+- **The `residual!` budgets are re-measured, and two of the four rows moved — downwards.**
+
+  | | 0.4.2 | 0.4.3 |
+  |---|---|---|
+  | `ShallowNet` | 11 424 | 11 424 |
+  | `ShallowNetReversible` | 11 424 | 11 424 |
+  | `ShallowNetAutodiff` | 54 656 | **52 096** |
+  | `ShallowNetAutodiffReversible` | 54 656 | **52 096** |
+
+  Worth stating rather than quietly re-recording, and worth noting which way: 0.4.2 moved these same
+  two rows *up* by 3 072 bytes and left the symbolic pair alone. This release moves them back down by
+  2 560 and again leaves the symbolic pair alone — so the autodiff path, which reaches its derivatives
+  through `ForwardDiff` rather than a generated kernel, is the one that feels these releases, and the
+  generated one is not. The ceilings (17 000 and 78 000) hold with room, so none of them moves.
+
+## [0.4.2] - 2026-08-26
+
+Julia 1.11 becomes the floor and `GeometricOptimizers` moves to 0.6. Nothing in this package's
+exported surface changes.
+
+> [!NOTE]
+> This entry was written after the fact. 0.4.2 was released without one; its content is taken from
+> the commit that made the change and from the figures recorded there.
+
+### Changed
+
+- **`GeometricOptimizers` 0.5 → 0.6.** 0.6.0 takes a whole `NetworkParameters` through the optimizer
+  and is breaking: it deletes four `outer!`/`_mul!` methods, one `update!(::BFGSState, …)`, `add!` on
+  a parameter set, and two `l2norm` methods that moved upstream to `GeometricBase`. Nothing here hands
+  it a container, so the bump is a compat entry and no code.
+
+- **`NeuralNetworkParameters` 0.2.1 → 0.2.2**, which is what `SymbolicNeuralNetworks` 0.7.1 requires
+  anyway.
+
+- **Julia 1.11 is the floor**, in step with `NeuralNetworkParameters`, `SimpleSolvers`,
+  `GeometricOptimizers`, `AbstractNeuralNetworks`, `SymbolicNeuralNetworks` and
+  `GeometricMachineLearning`. `GeometricBase` deliberately stays on 1.10.
+
+- **The `residual!` budgets were re-measured on 1.11.9 rather than carried over**, and two of the four
+  rows moved: `ShallowNetAutodiff` and `ShallowNetAutodiffReversible` from 51 584 to 54 656, while
+  `ShallowNet` and `ShallowNetReversible` stayed at 11 424. The prediction had been the other way
+  round — `NeuralNetworkParameters` 0.2.2 took `SymbolicNeuralNetworks`' single-sample split from 768
+  bytes to 560, and the symbolic `residual!` here calls `DQDθ` on a length-one `Vector`, so that is
+  the path it takes — and it moved this figure by nothing.
+
 ## [0.4.1] - 2026-08-25
 
 Three compat bounds move together, and the two things the releases behind them bring make code

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearIntegrators"
 uuid = "4ad56de4-0342-4c02-9694-ab2f23251d8c"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]
@@ -23,47 +23,55 @@ SymbolicNeuralNetworks = "aed23131-dcd0-47ca-8090-d21e605652e3"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-# 0.7.1 and not 0.7. 0.7.0 pins `NeuralNetworkParameters = "0.1"`, so it cannot coexist with the
-# 0.2 container this package requires below -- a bound of "0.7" admits a version that is never
-# satisfiable here. The resolver works that out on its own, but a bound is a statement about what
-# this package supports, and this one would be making a false one. `SymbolicNeuralNetworks` 0.7
-# names 0.7.1 for the same reason.
-AbstractNeuralNetworks = "0.7.1"
+# 0.8.0 takes a whole set of parameters as a `NetworkParameters` and renames `ArrayNamedTuple` to
+# `NamedTupleOfArrays`. Neither reaches this package: nothing here names either alias, and the
+# parameters this package builds are handed to `Optimizer` already flattened. The bump moves with
+# `NeuralNetworkParameters` and `SymbolicNeuralNetworks` below -- 0.8.0 requires the 0.3 container --
+# so the three move together or none of them resolves.
+AbstractNeuralNetworks = "0.8"
 CompactBasisFunctions = "0.3"
 ForwardDiff = "1"
-GeometricBase = "0.14.8"
+GeometricBase = "0.14.9"
 GeometricEquations = "0.21"
 GeometricIntegratorsBase = "0.6.3"
-# 0.5.0 drops the `ParameterHandling` shim and lets `NeuralNetworkParameters` do the flattening,
-# which makes the 0.2 container a requirement rather than a choice: 0.4 and earlier want the 0.1
-# container. This bound and the two below therefore move together or none of them resolves. 0.6.0
-# takes a whole `NetworkParameters` through the optimizer; nothing here hands it one -- the
-# `ShallowNet` initialisation flattens to a plain `Vector` before `Optimizer` sees it
-# (`src/nvi/shallownet.jl`) -- so the bump is a compat entry and no code.
-GeometricOptimizers = "0.6"
+# 0.7.0 takes a whole set of parameters *only* as a `NetworkParameters`, and turns a bare
+# `NamedTuple` away at `Optimizer`. That is the breaking half of the de-piracy wave and it costs this
+# package nothing, for the reason the 0.6.0 note already gave: the `ShallowNet` initialisation
+# flattens to a plain `Vector` before `Optimizer` sees it (`src/nvi/shallownet.jl`), so no parameter
+# set is ever handed over whole. The bump is a compat entry and no code. It also requires
+# `SimpleSolvers` 0.13.2, which is why that bound moved below.
+GeometricOptimizers = "0.7"
 GeometricSolutions = "0.6"
 LinearAlgebra = "1"
-# 0.2.1 and not 0.2. The call sites here name only `NetworkParameters`, `params`, `flatten`,
-# `unflatten` and `unflatten!`, all of which 0.2.0 has, so this is not a bound about what loads.
-# It is a bound about what `test/quality/inference_and_allocations.jl` measures: the un-batched
-# `unflatten` on the symbolic `residual!` path is this package's dependency directly, and 0.2.1 is
-# the release that took its `map` over a closure off the per-call path
-# (NeuralNetworkParameters#13). Against 0.2.0 the `ShallowNet` and `ShallowNetReversible` budgets
-# fail on Julia 1.10 -- that is the downstream half of SymbolicNeuralNetworks#55, whose upstream
-# half is `SymbolicNeuralNetworks` 0.7.0. SNN 0.7 pins 0.2.1 itself, so today's resolution would
-# be right either way; this states the requirement rather than inheriting it. 0.2.2 moves the same
-# figure again and downwards, by writing the across-children walks out instead of recursing with
-# `Base.tail`; the budgets below are measured against it.
-NeuralNetworkParameters = "0.2.2"
+# 0.3.0 removes `ParameterSet`, the `Union{NetworkParameters, NamedTuple}` the rest of this
+# ecosystem dispatched on. The call sites here name only `NetworkParameters`, `params`, `flatten`,
+# `unflatten` and `unflatten!`, none of which changed, so this is not a bound about what loads.
+#
+# It is a bound about what `test/quality/inference_and_allocations.jl` measures. Those budgets were
+# set against 0.2.2, whose across-children walks are written out rather than recursed with
+# `Base.tail`; the un-batched `unflatten` on the symbolic `residual!` path is this package's
+# dependency directly. **They were re-measured against 0.3.0 and hold unchanged** -- 0.3.0 touches the
+# type a set is dispatched on, not the walk a set is flattened by.
+#
+# 0.3.0 also takes `GeometricBase` as a hard dependency, for `L2norm` over a parameter set, which is
+# why the bound above is 0.14.9 rather than 0.14.8.
+NeuralNetworkParameters = "0.3"
 QuadratureRules = "0.2"
 Random = "1"
-SimpleSolvers = "0.12.1, 0.13"
+# 0.13.2 and not "0.12.1, 0.13": `GeometricOptimizers` 0.7.0 requires it, so the lower halves of that
+# range are no longer reachable from here. 0.13.2 is also where `GradientAutodiff`, `GradientFunction`
+# and `alloc_h` for a parameter set live, as an extension on `NeuralNetworkParameters` -- they were
+# `GeometricOptimizers`' type piracy until 0.7.0. Nothing here calls them; this package hands the
+# solver a flat `Vector`.
+SimpleSolvers = "0.13.2"
 StaticArrays = "1"
 Statistics = "1"
-# 0.7.0 is the first release that permits the 0.2 container; 0.6.0 allows only 0.1. It also
-# carries the upstream half of SymbolicNeuralNetworks#55 -- see the `NeuralNetworkParameters`
-# bound above. 0.7.1 writes the batched half of that walk out as well, which this package does not
-# reach (`residual!` calls `DQDθ` on a length-one `Vector`) but which moves nothing here either way.
-SymbolicNeuralNetworks = "0.7"
+# 0.8.0 gives an equation set its own name back -- `EquationSet`, which 0.7 had folded into
+# `NeuralNetworkParameters.ParameterSet` -- and is the first release permitting the 0.3 container.
+# Nothing here names `EquationSet`: this package builds its symbolic functions through
+# `build_nn_function` on a network, so the shape it passes is the one `SymbolicNeuralNetwork` gives
+# it. The batched half of the SymbolicNeuralNetworks#55 walk is still not reached (`residual!` calls
+# `DQDθ` on a length-one `Vector`).
+SymbolicNeuralNetworks = "0.8"
 Symbolics = "7"
 julia = "1.11"

--- a/test/unit/network_integrators_unit.jl
+++ b/test/unit/network_integrators_unit.jl
@@ -11,27 +11,7 @@
 # The `Float16` OGA dictionary regression below is *not* part of the cross-product and keeps
 # its own testset.
 
-# ---- determinism -------------------------------------------------------------
-#
-# Every case below builds a network with random weights, and the OGA/Newton path on those weights is
-# ill-conditioned by nature: `Float32` `ShallowNet` under `OGA1dStable` sits close enough to a
-# singular Gram matrix that whether it *is* singular depends on which weights were drawn.
-#
-# Without this line the draw depends on how many times `rand` was called by whatever ran earlier in
-# `runtests.jl`, which differs by platform and by Julia version -- so the suite was a lottery whose
-# odds changed whenever an unrelated dependency moved. That is what it looked like: `SingularException(13)`
-# on 8 of 13 CI jobs on one branch and 5 of 13 on another with *identical* dependency versions, while
-# 24 consecutive local runs on macOS ARM passed. `main` being green on 2026-08-26 was a draw, not a
-# state.
-#
-# Seeded here rather than in `testsetup.jl` so that this file's draws do not depend on the include
-# order in `runtests.jl`. `dispatch_variants_unit.jl` already does the same for its reference check,
-# and for the same reason.
-Random.seed!(0xC0FFEE)
-
 # ---- accuracy guards: default seed, ten steps, analytic reference ------------
-#
-# "seed" here is the `initial_guess_method`, not an RNG seed -- see `NETWORK_INTEGRATORS`.
 for row in NETWORK_INTEGRATORS, T in TEST_TYPES
     row.tol === nothing && continue
     accuracy_guard(row.name, row.make, T; tol = getfield(row.tol, Symbol(T)),

--- a/test/unit/network_integrators_unit.jl
+++ b/test/unit/network_integrators_unit.jl
@@ -11,7 +11,27 @@
 # The `Float16` OGA dictionary regression below is *not* part of the cross-product and keeps
 # its own testset.
 
+# ---- determinism -------------------------------------------------------------
+#
+# Every case below builds a network with random weights, and the OGA/Newton path on those weights is
+# ill-conditioned by nature: `Float32` `ShallowNet` under `OGA1dStable` sits close enough to a
+# singular Gram matrix that whether it *is* singular depends on which weights were drawn.
+#
+# Without this line the draw depends on how many times `rand` was called by whatever ran earlier in
+# `runtests.jl`, which differs by platform and by Julia version -- so the suite was a lottery whose
+# odds changed whenever an unrelated dependency moved. That is what it looked like: `SingularException(13)`
+# on 8 of 13 CI jobs on one branch and 5 of 13 on another with *identical* dependency versions, while
+# 24 consecutive local runs on macOS ARM passed. `main` being green on 2026-08-26 was a draw, not a
+# state.
+#
+# Seeded here rather than in `testsetup.jl` so that this file's draws do not depend on the include
+# order in `runtests.jl`. `dispatch_variants_unit.jl` already does the same for its reference check,
+# and for the same reason.
+Random.seed!(0xC0FFEE)
+
 # ---- accuracy guards: default seed, ten steps, analytic reference ------------
+#
+# "seed" here is the `initial_guess_method`, not an RNG seed -- see `NETWORK_INTEGRATORS`.
 for row in NETWORK_INTEGRATORS, T in TEST_TYPES
     row.tol === nothing && continue
     accuracy_guard(row.name, row.make, T; tol = getfield(row.tol, Symbol(T)),


### PR DESCRIPTION
Six compat bounds move together, and none of them reaches code here.

## One constraint, not six

`NeuralNetworkParameters` 0.3.0 removes `ParameterSet`, the `Union{NetworkParameters, NamedTuple}` this ecosystem dispatched on, because a method written on it was a method on `Base.NamedTuple`. Every other bound follows from that one:

| | was | is |
|---|---|---|
| `NeuralNetworkParameters` | `0.2.2` | **`0.3`** |
| `AbstractNeuralNetworks` | `0.7.1` | **`0.8`** |
| `SymbolicNeuralNetworks` | `0.7` | **`0.8`** |
| `GeometricOptimizers` | `0.6` | **`0.7`** |
| `SimpleSolvers` | `0.12.1, 0.13` | **`0.13.2`** |
| `GeometricBase` | `0.14.8` | **`0.14.9`** |

The middle three are the first releases of their packages that permit the 0.3 container; `GeometricOptimizers` 0.7.0 requires `SimpleSolvers` 0.13.2; and `NeuralNetworkParameters` 0.3.0 takes `GeometricBase` as a hard dependency at 0.14.9, for `L2norm` over a parameter set. Any one of them alone is unsatisfiable.

## Nothing here changes

`src/` and `test/` name neither `ParameterSet` nor `EquationSet` nor `ArrayNamedTuple`. The call sites reach only `NetworkParameters`, `params`, `flatten`, `unflatten` and `unflatten!`, none of which changed.

`GeometricOptimizers` 0.7.0 takes a whole set of parameters **only** as a `NetworkParameters` and turns a bare `NamedTuple` away at `Optimizer`. That is the breaking half of the wave and it costs this package nothing, for the reason 0.4.2's note already gave: the `ShallowNet` initialisation flattens to a plain `Vector` before `Optimizer` sees it (`src/nvi/shallownet.jl`), so no parameter set is ever handed over whole.

## The `residual!` budgets moved, downwards

Re-measured rather than carried over:

| | 0.4.2 | 0.4.3 |
|---|---|---|
| `ShallowNet` | 11 424 | 11 424 |
| `ShallowNetReversible` | 11 424 | 11 424 |
| `ShallowNetAutodiff` | 54 656 | **52 096** |
| `ShallowNetAutodiffReversible` | 54 656 | **52 096** |

Worth stating which way, because 0.4.2 moved these same two rows *up* by 3 072 and left the symbolic pair alone. This moves them back down by 2 560 and again leaves the symbolic pair alone — so the autodiff path, which reaches its derivatives through `ForwardDiff` rather than a generated kernel, is the one that feels these releases, and the generated one is not. The ceilings (17 000 and 78 000) hold with room, so none of them moves.

## Also

The changelog gains the **0.4.2 entry it was released without**, reconstructed from that release's own commit and marked as written after the fact.

## Version

**0.4.3.** Compat only; the exported surface is unchanged.

## Verified

Full suite passes — 1981 passed, 2 broken, unchanged. The pre-push hook's `Pkg.test` also ran clean, which it could not have before these releases were registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)