### PR TITLE
[do not merge] CI baseline on main's dependency bounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,3 +102,4 @@ jobs:
                   using NonlinearIntegrators
                   DocMeta.setdocmeta!(NonlinearIntegrators, :DocTestSetup, :(using NonlinearIntegrators); recursive=true)
                   doctest(NonlinearIntegrators)
+


### PR DESCRIPTION
**Not for merge.** This exists to run `main`'s dependency bounds on today's runners.

#96 fails with `SingularException(13)` in a `Float32` Newton solve on 8 of 13 jobs. It does not reproduce locally on macOS ARM under *either* the old or the new bounds — 12/12 clean both ways — and both environments resolve to identical versions of everything the change touches. So the local A/B cannot attribute it.

`main`'s last CI run was 2026-08-26, before this wave's releases *and* before unrelated patch releases moved. This runs main's bounds now, so the comparison is one variable rather than two.

- If this fails the same way, #96 is not the cause and the failure is a pre-existing platform-dependent flake in an unseeded `Float32` solve.
- If this passes, the bump is implicated and I bisect the six bounds.

Close once it has answered.